### PR TITLE
gh actions: e2e: add basic-install lane

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,77 @@
+name: CI E2E
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: 
+      - main
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  e2e-basic-install:
+    runs-on: ubuntu-20.04
+    env:
+      built_image: "rte-operator:ci" # Arbitrary name
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
+
+    - name: Set up golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Verify modules
+      run: go mod verify
+
+    - name: build test binary
+      run: |
+        make binary-e2e
+
+    - name: Build image
+      run: |
+        docker build . -t ${built_image}
+
+    - name: Create K8s Kind Cluster
+      run: |
+        # kind is part of 20.04 image, see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+        kind create cluster --config=hack/kind-config-e2e-no-registry.yaml --image kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        kubectl label node kind-worker node-role.kubernetes.io/worker=''
+        kind load docker-image ${built_image}
+
+    - name: Deploy RTE Operator
+      run: |
+        IMG=${built_image} KUSTOMIZE_DEPLOY_DIR="config/kind-ci/" make deploy
+
+    - name: E2E Tests
+      run: |
+        export KUBECONFIG=${HOME}/.kube/config
+        ./bin/e2e.test -ginkgo.focus='\[BasicInstall\]'
+
+    - name: Archive E2E Tests logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: test_e2e_logs
+        path: /tmp/test_e2e_logs/
+
+    - name: Export kind logs
+      if: ${{ failure() }}
+      run: |
+        kind export logs /tmp/kind_logs
+
+    - name: Archive kind logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: kind_logs
+        path: /tmp/kind_logs

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v2
         id: go
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Set release version env var
         run: |

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: rte-operator-system
+namespace: rte
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: rte-operator-
+namePrefix: rte-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,6 +22,7 @@ spec:
           name: https
       - name: manager
         args:
+        - "--platform=kubernetes"
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,6 +5,12 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: manager-config
-  files:
+- files:
   - controller_manager_config.yaml
+  name: manager-config
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: rte-operator
+  newTag: ci

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,7 +26,7 @@ spec:
         runAsNonRoot: true
       containers:
       - command:
-        - /manager
+        - /bin/rte-operator
         args:
         - --leader-elect
         image: controller:latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,93 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversionss
+  verbs:
+  - list
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
   - topologyexporter.openshift-kni.io
   resources:
   - resourcetopologyexporters

--- a/controllers/resourcetopologyexporter_controller.go
+++ b/controllers/resourcetopologyexporter_controller.go
@@ -63,8 +63,20 @@ type ResourceTopologyExporterReconciler struct {
 	ImageSpec    string
 }
 
-// TODO: missing permissions (roles, rolebinding, serviceaccount, daemonset...)
+// TODO: narrow down
 
+// Namespace Scoped
+// TODO
+
+// Cluster Scoped
+//+kubebuilder:rbac:groups=topology.node.k8s.io,resources=noderesourcetopologies,verbs=get;list;create;update
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversionss,verbs=list
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=topologyexporter.openshift-kni.io,resources=resourcetopologyexporters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=topologyexporter.openshift-kni.io,resources=resourcetopologyexporters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=topologyexporter.openshift-kni.io,resources=resourcetopologyexporters/finalizers,verbs=update

--- a/hack/config/kind-ci/imagePullPolicyNever.yaml
+++ b/hack/config/kind-ci/imagePullPolicyNever.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          imagePullPolicy: Never

--- a/hack/config/kind-ci/kustomization.yaml
+++ b/hack/config/kind-ci/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../default
+
+patchesStrategicMerge:
+- imagePullPolicyNever.yaml

--- a/hack/kind-config-e2e-no-registry.yaml
+++ b/hack/kind-config-e2e-no-registry.yaml
@@ -1,0 +1,13 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+- |
+  kind: KubeletConfiguration
+  cpuManagerPolicy: "static"
+  topologyManagerPolicy: "single-numa-node"
+  reservedSystemCPUs: "0"
+  featureGates:
+    KubeletPodResourcesGetAllocatable: true
+nodes:
+- role: control-plane
+- role: worker

--- a/hack/kind-config-e2e-no-registry.yaml
+++ b/hack/kind-config-e2e-no-registry.yaml
@@ -4,10 +4,16 @@ kubeadmConfigPatches:
 - |
   kind: KubeletConfiguration
   cpuManagerPolicy: "static"
+  cpuManagerReconcilePeriod: "5s"
   topologyManagerPolicy: "single-numa-node"
   reservedSystemCPUs: "0"
   featureGates:
     KubeletPodResourcesGetAllocatable: true
+  memoryManagerPolicy: "Static"
+  systemReserved: {"memory" :"512Mi"}
+  kubeReserved: {"memory" :"512Mi"}
+  evictionHard: {"memory.available": "100Mi"}
+  reservedMemory: [{"numaNode": 0, "limits": {"memory": "1124Mi"}}]
 nodes:
 - role: control-plane
 - role: worker


### PR DESCRIPTION
This PR is the first step towards fully automated CI.
First and foremost, we add the very first, coarse grained, RBAC definitions.
Then we kick off a kubernetes e2e lane which run only the bare minimum tests.
All the work in this PR is meant to be further refined in followup PRs.

Next steps:

- add more tests to the install lane
- run the imported RTE e2e suite
- make platform autodetection work
- run the lane(s) also against OCP